### PR TITLE
Fix CSV ser/des for strings within compound types when using Clickhou…

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -127,6 +127,7 @@ LIBDESSSER_SOURCES = \
 	src/DessserMasks.ml \
 	src/DessserPrinter.ml \
 	src/DessserCompilationUnit.ml \
+	src/DessserConfigs.ml \
 	src/Dessser.ml \
 	src/DessserLeftistHeap.ml \
 	src/DessserOCamlBackEndHelpers.ml \
@@ -278,6 +279,7 @@ LINKED_FOR_TESTS = \
 	src/DessserMasks.ml \
 	src/DessserPrinter.ml \
 	src/DessserCompilationUnit.ml \
+	src/DessserConfigs.ml \
 	src/Dessser.ml \
 	src/DessserLeftistHeap.ml \
 	src/DessserOCamlBackEndHelpers.ml \
@@ -510,9 +512,42 @@ json-check: src/dessserc $(JSON_TESTS)
 	done
 	@echo SUCCESS
 
+CSV_TESTS = \
+  tests/csv/array_of_strings.type
+
+csv-check: src/dessserc $(CSV_TESTS)
+	@set -e ;\
+	for be in OCaml C++; do \
+	  for f in $(CSV_TESTS); do \
+	    echo "Testing $$f" ;\
+	    base=tests/csv/$$(basename $$f .type) ;\
+	    src/dessserc converter \
+	      --schema=@$$f \
+	      --backend=$$be \
+	      --input-encoding=csv \
+	      --output-encoding=s-expr \
+	      --csv-separator='\t' \
+	      --csv-quote= \
+	      --csv-null='\\N' \
+	      --csv-clickhouse-syntax \
+	      --sexpr-newline='\n' \
+	      --dev-mode -O3 --keep-temp-files -o $$base ;\
+	    for in in $$base.*.in; do \
+	      out=/tmp/$$(basename $$in .in).out ;\
+	      expected=tests/csv/$$(basename $$in .in).out ;\
+	      echo "Running: $$base -i $$in > $$out" ;\
+	      $$base -i $$in > $$out ;\
+	      echo >> $$out ;\
+	      diff $$expected $$out ;\
+	    done ;\
+	  done ;\
+	done
+	@echo SUCCESS
+
 check: \
   unit-check examples-check cpp-check dump-load-check convert-check \
-  aggregator-simplest-check aggregator-sets-check dessserc-check json-check
+  aggregator-simplest-check aggregator-sets-check dessserc-check \
+  json-check csv-check
 
 # Installation
 

--- a/examples/manual_codegen.ml
+++ b/examples/manual_codegen.ml
@@ -58,7 +58,7 @@ let () =
       exit 1
     ) in
   let module BE = (val backend : BACKEND) in
-  let sexpr_config = { DessserSExpr.default_config with newline = Some '\n' } in
+  let sexpr_config = { DessserConfigs.SExpr.default with newline = Some '\n' } in
   let convert_only = false in
   let compunit = U.make "manual_codegen" in
   let compunit, convert =

--- a/examples/simplest.ml
+++ b/examples/simplest.ml
@@ -17,6 +17,7 @@ struct
   type config = unit
   type state = unit
 
+  let select_config _csv _sexpr = ()
   let make_state ?(config=()) _mn0 = config
   let start _conf src = src
   let stop () src = src
@@ -87,6 +88,7 @@ struct
   type config = unit
   type state = unit
 
+  let select_config _csv _sexpr = ()
   let make_state ?(config=()) _ = config
   let start () dst = dst
   let stop () dst = dst

--- a/src/Dessser.ml
+++ b/src/Dessser.ml
@@ -39,6 +39,9 @@ sig
   (* RW state passed to every deserialization operations *)
   type state
 
+  (* Return the config from the set of all configured serializers: *)
+  val select_config : DessserConfigs.Csv.t -> DessserConfigs.SExpr.t -> config
+
   (* Build the initial state: *)
   val make_state : ?config:config -> T.mn -> state
 
@@ -138,6 +141,9 @@ sig
 
   (* RW state passed to every serialization operations *)
   type state
+
+  (* Return the config from the set of all configured serializers: *)
+  val select_config : DessserConfigs.Csv.t -> DessserConfigs.SExpr.t -> config
 
   (* Build the initial state: *)
   val make_state : ?config:config -> T.mn -> state

--- a/src/DessserConfigs.ml
+++ b/src/DessserConfigs.ml
@@ -1,0 +1,89 @@
+(* All module configurations are stored in this single module to work around
+ * dependency loops. *)
+
+module Csv =
+struct
+  type t =
+    { separator : char ;
+      (* Optional char to add (or skip) at the end of values: *)
+      newline : char option ;
+      null : string ;
+      (* If None, strings are never quoted. Otherwise, look for quotes. *)
+      quote : char option ;
+      true_ : string ;
+      false_ : string ;
+      vectors_of_chars_as_string : bool ;
+      (* Are values (esp. of compound types) encoded as described in
+       * https://clickhouse.tech/docs/en/interfaces/formats#csv ? *)
+      clickhouse_syntax : bool }
+
+  let default =
+    { separator = ',' ;
+      newline = Some '\n' ;
+      null = "\\N" ;  (* À la Postgresql *)
+      quote = Some '"' ;
+      true_ = "T" ;
+      false_ = "F" ;
+      vectors_of_chars_as_string = true ;
+      clickhouse_syntax = false }
+
+  let make separator newline null quote true_ false_ vectors_of_chars_as_string
+           clickhouse_syntax =
+    (* We want command line to be able to set no quote with an empty string: *)
+    let quote =
+      match quote with
+      | None -> None
+      | Some "" -> None
+      | Some s ->
+          assert (String.length s = 1) ;
+          Some s.[0] in
+    { separator ;
+      newline ;
+      null ;
+      quote ;
+      true_ ;
+      false_ ;
+      vectors_of_chars_as_string ;
+      clickhouse_syntax }
+end
+
+module Json =
+struct
+  type t = { newline : char option }
+
+  let default = { newline = None } ;
+end
+
+module SExpr =
+struct
+  type t =
+    { list_prefix_length : bool ;
+      (* Optional char added (or skipped) at end of values: *)
+      newline : char option }
+
+  let default =
+    { list_prefix_length = true ;
+      newline = None }
+
+  let make list_prefix_length newline =
+    { list_prefix_length ; newline }
+end
+
+type all =
+  { mutable csv : Csv.t ;
+    null : unit ;
+    mutable json : Json.t ;
+    ringbuf : unit ;
+    rowbinary : unit ;
+    mutable sexpr : SExpr.t }
+
+type all_ser = all
+type all_des = all
+
+let make_default () =
+  { csv = Csv.default ;
+    null = () ;
+    json = Json.default ;
+    ringbuf = () ;
+    rowbinary = () ;
+    sexpr = SExpr.default }

--- a/src/DessserDevNull.ml
+++ b/src/DessserDevNull.ml
@@ -12,6 +12,8 @@ struct
   type config = unit
   type state = unit
 
+  let select_config _csv _sexpr = ()
+
   let make_state ?(config=()) _ = config
 
   let start _conf p = p

--- a/src/DessserQCheck.ml
+++ b/src/DessserQCheck.ml
@@ -815,7 +815,7 @@ let rec sexpr_of_typ_gen ?sexpr_config typ =
       list_repeat dim (sexpr_of_mn_gen ?sexpr_config mn) |> map to_sexpr
   | TArr mn ->
       tiny_list (sexpr_of_mn_gen ?sexpr_config mn) |> map (fun lst ->
-        (if DessserSExpr.((sexpr_config |? default_config).list_prefix_length)
+        (if DessserSExpr.((sexpr_config |? DessserConfigs.SExpr.default).list_prefix_length)
         then
           Stdlib.string_of_int (List.length lst) ^ " "
         else "") ^
@@ -1009,7 +1009,7 @@ let sexpr ?sexpr_config mn =
       (module DessserCsv.Ser : SER) format ;
     let format = "JSON" in
     let sexpr_config =
-      DessserSExpr.{ default_config with list_prefix_length = false } in
+      DessserConfigs.SExpr.{ default with list_prefix_length = false } in
     test_format ~sexpr_config ocaml_be mn
       (module DessserJson.Des : DES)
       (module DessserJson.Ser : SER) format ;
@@ -1199,7 +1199,7 @@ let sexpr ?sexpr_config mn =
     let mn = P.mn_of_string ts in
     let module DS = DesSer (DessserCsv.Des) (DessserSExpr.Ser) in
     let ser_config =
-      DessserSExpr.{ default_config with list_prefix_length = false } in
+      DessserConfigs.SExpr.{ default with list_prefix_length = false } in
     let exe =
       let e =
         func2 T.ptr T.ptr (fun src dst ->
@@ -1224,7 +1224,7 @@ let sexpr ?sexpr_config mn =
     String.trim (run_converter ~timeout:2 exe vs)
 
   let csv_config_0 =
-    DessserCsv.{ default_config with
+    DessserConfigs.Csv.{ default with
       separator = '|' ;
       null = "" ;
       true_ = "true" ;
@@ -1232,23 +1232,23 @@ let sexpr ?sexpr_config mn =
       clickhouse_syntax = false }
 
   let csv_config_1 =
-    DessserCsv.{ default_config with
+    DessserConfigs.Csv.{ default with
       null = "" ;
       true_ = "true" ;
       false_ = "false" ;
       clickhouse_syntax = false }
 
   let csv_config_2 =
-    DessserCsv.{ default_config with quote = None }
+    DessserConfigs.Csv.{ default with quote = None }
 
   let csv_config_CH =
-    DessserCsv.{ default_config with
+    DessserConfigs.Csv.{ default with
       true_ = "1" ;
       false_ = "0" ;
       clickhouse_syntax = true }
 
   let csv_config_ramen =
-    DessserCsv.{ default_config with
+    DessserConfigs.Csv.{ default with
       separator = '\t' ;
       quote = None ;
       clickhouse_syntax = true }

--- a/src/DessserRamenRingBuffer.ml
+++ b/src/DessserRamenRingBuffer.ml
@@ -266,6 +266,8 @@ struct
   let enter_frame_dyn = enter_frame identity zero_nullmask_dyn
   let enter_frame_const = enter_frame u8_of_int zero_nullmask_const
 
+  let select_config _csv _sexpr = ()
+
   let with_nullbit_done mn0 path p_stk f =
     E.with_sploded_pair "with_nullbit_done1" p_stk (fun p stk ->
       let stk = may_set_nullbit true mn0 path stk in
@@ -658,6 +660,8 @@ struct
             else p
           and stk = cons new_frame stk in
           make_pair p stk ]
+
+  let select_config _csv _sexpr = ()
 
   let make_state ?(config=()) _mn = config
 

--- a/src/DessserRowBinary.ml
+++ b/src/DessserRowBinary.ml
@@ -14,6 +14,8 @@ struct
   type config = unit
   type state = unit
 
+  let select_config _csv _sexpr = ()
+
   let make_state ?(config=()) _mn = config
 
   let start () p = p
@@ -221,6 +223,8 @@ struct
   let id = RowBinary
   type config = unit
   type state = unit
+
+  let select_config _csv _sexpr = ()
 
   let make_state ?(config=()) _mn = config
 


### PR DESCRIPTION
…se syntax

Had to make ser/des configuration accessible from dessserc command line.

(cherry picked from commit d702def7eb60632761a53204879eb7d61ddfd053)